### PR TITLE
Update build_defs.bzl

### DIFF
--- a/bazel/build_defs.bzl
+++ b/bazel/build_defs.bzl
@@ -36,6 +36,7 @@ _DEFAULT_CPPOPTS.extend([
     # "-Wshorten-64-to-32",  # not in GCC (and my Kokoro images doesn't have Clang)
     "-Werror",
     "-Wno-long-long",
+    "-Wno-deprecated-copy",
 ])
 _DEFAULT_COPTS.extend([
     "-std=c99",


### PR DESCRIPTION
fix upb deprecated-copy error